### PR TITLE
feat(Source:OSM): Use SourceXYZComponent as parent class instead of S…

### DIFF
--- a/src/components/sources/osm.component.ts
+++ b/src/components/sources/osm.component.ts
@@ -2,6 +2,7 @@ import { Component, Host, OnInit, forwardRef, Input } from '@angular/core';
 import { source, AttributionLike, TileLoadFunctionType } from 'openlayers';
 import { LayerTileComponent } from '../layers';
 import { SourceComponent } from './source.component';
+import { SourceXYZComponent } from './xyz.component';
 
 @Component({
   selector: 'aol-source-osm',
@@ -10,7 +11,7 @@ import { SourceComponent } from './source.component';
     { provide: SourceComponent, useExisting: forwardRef(() => SourceOsmComponent) }
   ]
 })
-export class SourceOsmComponent extends SourceComponent implements OnInit {
+export class SourceOsmComponent extends SourceXYZComponent implements OnInit {
   instance: source.OSM;
 
   @Input() attributions: AttributionLike;


### PR DESCRIPTION
…ourceComponent

Changed OSM parent class to reflect [openlayers hierarchy](https://openlayers.org/en/latest/apidoc/ol.source.OSM.html) 

@Neonox31 @davinkevin 