### PR TITLE
fix(source.XYZ): instantiate XYZ source even if no tileGrid is provided

### DIFF
--- a/src/components/sources/xyz.component.ts
+++ b/src/components/sources/xyz.component.ts
@@ -38,9 +38,9 @@ export class SourceXYZComponent extends SourceComponent implements AfterContentI
   ngAfterContentInit() {
     if (this.tileGridXYZ) {
       this.tileGrid = this.tileGridXYZ.instance;
-      this.instance = new source.XYZ(this);
-      this.host.instance.setSource(this.instance);
     }
+    this.instance = new source.XYZ(this);
+    this.host.instance.setSource(this.instance);
   }
 
   ngOnChanges(changes: SimpleChanges) {


### PR DESCRIPTION
If I try to add a source.XYZ on the map, it is not displayed.
The official example for OpenLayers XYZ cannot work ([http://openlayers.org/en/latest/examples/xyz.html](http://openlayers.org/en/latest/examples/xyz.html))

This fix solves this problem.

@aymeric-duchein 