### PR TITLE
refactor(misc): fix dev dependencies

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -27,7 +27,7 @@
     "zone.js": "^0.8.14"
   },
   "devDependencies": {
-    "@angular/cli": "1.6.0",
+    "@angular/cli": "1.6.8",
     "@angular/compiler-cli": "^5.0.0",
     "@angular/language-service": "^5.0.0",
     "typescript": "~2.4.2"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "main": "./dist/index.js",
     "typings": "./dist/index.d.ts",
     "dependencies": {
-        "@angular/animations": "^4.1.3",
         "@types/openlayers": "4.3.x || 4.4.x",
         "openlayers": "4.3.x || 4.4.x"
     },
@@ -41,8 +40,6 @@
         "@angular/compiler": "^4.1.3",
         "@angular/compiler-cli": "^4.1.3",
         "@angular/core": "^4.1.3",
-        "@angular/platform-browser": "^4.1.3",
-        "@angular/platform-server": "^4.1.3",
         "@types/jasmine": "^2.5.38",
         "@types/selenium-webdriver": "^3.0.4",
         "codelyzer": "3.0.1",


### PR DESCRIPTION
since it's only necessary for the example, I moved @angular/animations into dev dependencies to avoid warning messages when using ngx-openlayers with recent angular versions.