### PR TITLE
feature: add format geojson component

### DIFF
--- a/src/components/formats/geojson.component.ts
+++ b/src/components/formats/geojson.component.ts
@@ -1,0 +1,23 @@
+import { Component, forwardRef, Input } from '@angular/core';
+import { format, ProjectionLike } from 'openlayers';
+import { FormatComponent } from './format.component';
+
+@Component({
+  selector: 'aol-format-geojson',
+  template: '',
+  providers: [
+    { provide: FormatComponent, useExisting: forwardRef(() => FormatGeoJSONComponent) }
+  ]
+})
+export class FormatGeoJSONComponent extends FormatComponent {
+  instance: format.GeoJSON;
+  
+  @Input() defaultDataProjection: ProjectionLike = 'EPSG:4326';
+  @Input() featureProjection: ProjectionLike;
+  @Input() geometryName: string;
+
+  constructor() {
+    super();
+    this.instance = new format.GeoJSON(this);
+  }
+}

--- a/src/components/formats/index.ts
+++ b/src/components/formats/index.ts
@@ -1,2 +1,3 @@
 export * from './format.component';
 export * from './mvt.component';
+export * from './geojson.component';

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import {
   ControlAttributionComponent, ControlFullScreenComponent, ControlMousePositionComponent,
   ControlOverviewMapComponent, ControlRotateComponent, ControlScaleLineComponent, ControlZoomComponent, ControlZoomSliderComponent,
   ControlZoomToExtentComponent, DefaultControlComponent, ControlComponent,
-  FormatMVTComponent,
+  FormatMVTComponent, FormatGeoJSONComponent,
   TileGridComponent, TileGridWMTSComponent,
   DefaultInteractionComponent, DragRotateInteractionComponent, DragRotateAndZoomInteractionComponent,
   DoubleClickZoomInteractionComponent, DragAndDropInteractionComponent, DragBoxInteractionComponent,
@@ -79,6 +79,7 @@ const COMPONENTS = [
   ControlZoomToExtentComponent,
 
   FormatMVTComponent,
+  FormatGeoJSONComponent,
   TileGridComponent,
   TileGridWMTSComponent,
 


### PR DESCRIPTION
Add the format geojson component, so i can reproduce this:

```javascript
new ol.layer.VectorTile({
    source: new ol.source.VectorTile({
        format: new ol.format.GeoJSON(),
             url: "somelayer/{z}/{x}/{y}.geojson"
    }),
});
```