### PR TITLE
Fix check host instance source

### DIFF
--- a/projects/ngx-openlayers/src/lib/sources/source.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/source.component.ts
@@ -14,7 +14,7 @@ export class SourceComponent implements OnDestroy {
   constructor(protected host: LayerComponent, protected raster?: SourceRasterComponent) {}
 
   ngOnDestroy() {
-    if (this.host) {
+    if (this.host && this.host.instance) {
       this.host.instance.setSource(null);
     }
 


### PR DESCRIPTION
The instance wasn't checked causing some `Cannot read property 'setSource' of undefined` when using *ngIf or other structural directives.

@Neonox31 @davinkevin @Yakoust @dabbid