### PR TITLE
Add OpenLayers typings and use to fix type mismatches

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@angular/cli": "^8.3.13",
     "@angular/compiler-cli": "^8.2.11",
     "@angular/language-service": "^8.2.11",
+    "@hanreev/types-ol": "^3.0.0",
     "@types/jasmine": "~3.3.8",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "~8.9.4",

--- a/projects/ngx-openlayers/src/lib/attribution.component.ts
+++ b/projects/ngx-openlayers/src/lib/attribution.component.ts
@@ -1,18 +1,15 @@
 import { Component, ElementRef, OnInit } from '@angular/core';
-import { Attribution } from 'ol/control';
 
 @Component({
   selector: 'aol-attribution',
   template: '<ng-content></ng-content>',
 })
 export class AttributionComponent implements OnInit {
-  instance: Attribution;
-  html: string;
+  label: string;
 
   constructor(private elementRef: ElementRef) {}
 
   ngOnInit() {
-    this.html = this.elementRef.nativeElement.innerHTML;
-    this.instance = new Attribution(this);
+    this.label = this.elementRef.nativeElement.innerHTML;
   }
 }

--- a/projects/ngx-openlayers/src/lib/attributions.component.ts
+++ b/projects/ngx-openlayers/src/lib/attributions.component.ts
@@ -1,5 +1,4 @@
 import { AfterViewInit, Component, ContentChildren, Host, QueryList } from '@angular/core';
-import { Attribution } from 'ol/control';
 import { SourceComponent } from './sources/source.component';
 import { AttributionComponent } from './attribution.component';
 
@@ -8,7 +7,7 @@ import { AttributionComponent } from './attribution.component';
   template: '<ng-content></ng-content>',
 })
 export class AttributionsComponent implements AfterViewInit {
-  instance: Array<Attribution>;
+  instance: Array<string>;
 
   @ContentChildren(AttributionComponent)
   attributions: QueryList<AttributionComponent>;
@@ -18,7 +17,7 @@ export class AttributionsComponent implements AfterViewInit {
   /* we can do this at the very end */
   ngAfterViewInit() {
     if (this.attributions.length) {
-      this.instance = this.attributions.map(cmp => cmp.instance);
+      this.instance = this.attributions.map(cmp => cmp.label);
       // console.log('setting attributions:', this.instance);
       this.source.instance.setAttributions(this.instance);
     }

--- a/projects/ngx-openlayers/src/lib/controls/attribution.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/attribution.component.ts
@@ -1,15 +1,15 @@
 import { Component, ElementRef, Input, OnDestroy, OnInit } from '@angular/core';
-import { Attribution } from 'ol/control';
+import Attribution, { Options as AttributionOptions } from 'ol/control/Attribution';
 import { MapComponent } from '../map.component';
 
 @Component({
   selector: 'aol-control-attribution',
   template: ``,
 })
-export class ControlAttributionComponent implements OnInit, OnDestroy {
+export class ControlAttributionComponent implements OnInit, OnDestroy, AttributionOptions {
   public componentType = 'control';
   instance: Attribution;
-  target: Element;
+  target: HTMLElement;
   @Input()
   collapsible: boolean;
 

--- a/projects/ngx-openlayers/src/lib/controls/control.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/control.component.ts
@@ -1,5 +1,5 @@
 import { Component, ContentChild, OnDestroy, OnInit } from '@angular/core';
-import { Control } from 'ol/control';
+import Control, { Options as ControlOptions } from 'ol/control/Control';
 import { MapComponent } from '../map.component';
 import { ContentComponent } from '../content.component';
 import { TileGridComponent } from '../tilegrid.component';
@@ -10,10 +10,10 @@ import { TileGridComponent } from '../tilegrid.component';
     <ng-content></ng-content>
   `,
 })
-export class ControlComponent implements OnInit, OnDestroy {
+export class ControlComponent implements OnInit, OnDestroy, ControlOptions {
   public componentType = 'control';
   instance: Control;
-  element: Element;
+  element: HTMLElement;
   @ContentChild(ContentComponent, { static: true })
   content: ContentComponent;
 

--- a/projects/ngx-openlayers/src/lib/controls/default.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/default.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnDestroy, OnInit, Input } from '@angular/core';
 import { Control, defaults } from 'ol/control';
+import { DefaultsOptions } from 'ol/control';
 import { Collection } from 'ol';
 import { Options as AttributionOptions } from 'ol/control/Attribution';
 import { Options as RotateOptions } from 'ol/control/Rotate';
@@ -11,7 +12,7 @@ import { MapComponent } from '../map.component';
   selector: 'aol-control-defaults',
   template: '',
 })
-export class DefaultControlComponent implements OnInit, OnDestroy {
+export class DefaultControlComponent implements OnInit, OnDestroy, DefaultsOptions {
   instance: Collection<Control>;
   @Input()
   attribution: boolean;

--- a/projects/ngx-openlayers/src/lib/controls/fullscreen.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/fullscreen.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
-import { FullScreen } from 'ol/control';
+import FullScreen, { Options as FullScreenOptions } from 'ol/control/FullScreen';
 import { MapComponent } from '../map.component';
 
 @Component({
@@ -8,7 +8,7 @@ import { MapComponent } from '../map.component';
     <ng-content></ng-content>
   `,
 })
-export class ControlFullScreenComponent implements OnInit, OnDestroy {
+export class ControlFullScreenComponent implements OnInit, OnDestroy, FullScreenOptions {
   instance: FullScreen;
 
   @Input()

--- a/projects/ngx-openlayers/src/lib/controls/mouseposition.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/mouseposition.component.ts
@@ -1,5 +1,5 @@
 import { Component, ElementRef, Input, OnDestroy, OnInit } from '@angular/core';
-import MousePosition from 'ol/control/MousePosition';
+import MousePosition, { Options as MousePositionOptions } from 'ol/control/MousePosition';
 import { MapComponent } from '../map.component';
 import { CoordinateFormat } from 'ol/coordinate';
 import { ProjectionLike } from 'ol/proj';
@@ -8,13 +8,13 @@ import { ProjectionLike } from 'ol/proj';
   selector: 'aol-control-mouseposition',
   template: ``,
 })
-export class ControlMousePositionComponent implements OnInit, OnDestroy {
+export class ControlMousePositionComponent implements OnInit, OnDestroy, MousePositionOptions {
   instance: MousePosition;
   @Input()
   coordinateFormat: CoordinateFormat;
   @Input()
   projection: ProjectionLike;
-  target: Element;
+  target: HTMLElement;
 
   constructor(private map: MapComponent, private element: ElementRef) {}
 

--- a/projects/ngx-openlayers/src/lib/controls/overviewmap.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/overviewmap.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnDestroy, OnInit, OnChanges, SimpleChanges } from '@angular/core';
 import { Layer } from 'ol/layer';
 import { View } from 'ol';
-import { OverviewMap } from 'ol/control';
+import OverviewMap, { Options as OverviewMapOptions } from 'ol/control/OverviewMap';
 import { MapComponent } from '../map.component';
 
 @Component({
@@ -10,7 +10,7 @@ import { MapComponent } from '../map.component';
     <ng-content></ng-content>
   `,
 })
-export class ControlOverviewMapComponent implements OnInit, OnChanges, OnDestroy {
+export class ControlOverviewMapComponent implements OnInit, OnChanges, OnDestroy, OverviewMapOptions {
   instance: OverviewMap;
   @Input()
   collapsed: boolean;
@@ -23,7 +23,7 @@ export class ControlOverviewMapComponent implements OnInit, OnChanges, OnDestroy
   @Input()
   layers: Layer[];
   @Input()
-  target: Element;
+  target: HTMLElement;
   @Input()
   tipLabel: string;
   @Input()

--- a/projects/ngx-openlayers/src/lib/controls/rotate.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/rotate.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
-import { Rotate } from 'ol/control';
+import Rotate, { Options as RotateOptions } from 'ol/control/Rotate';
 import { MapComponent } from '../map.component';
 
 @Component({
@@ -8,7 +8,7 @@ import { MapComponent } from '../map.component';
     <ng-content></ng-content>
   `,
 })
-export class ControlRotateComponent implements OnInit, OnDestroy {
+export class ControlRotateComponent implements OnInit, OnDestroy, RotateOptions {
   instance: Rotate;
 
   @Input()

--- a/projects/ngx-openlayers/src/lib/controls/scaleline.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/scaleline.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
-import { ScaleLine } from 'ol/control';
+import ScaleLine, { Options as ScaleLineOptions } from 'ol/control/ScaleLine';
 import { MapComponent } from '../map.component';
 
 @Component({
@@ -8,7 +8,7 @@ import { MapComponent } from '../map.component';
     <ng-content></ng-content>
   `,
 })
-export class ControlScaleLineComponent implements OnInit, OnDestroy {
+export class ControlScaleLineComponent implements OnInit, OnDestroy, ScaleLineOptions {
   instance: ScaleLine;
   @Input()
   units: string;

--- a/projects/ngx-openlayers/src/lib/controls/zoom.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/zoom.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
-import { Zoom } from 'ol/control';
+import Zoom, { Options as ZoomOptions } from 'ol/control/Zoom';
 import { MapComponent } from '../map.component';
 
 @Component({
@@ -8,15 +8,15 @@ import { MapComponent } from '../map.component';
     <ng-content></ng-content>
   `,
 })
-export class ControlZoomComponent implements OnInit, OnDestroy {
+export class ControlZoomComponent implements OnInit, OnDestroy, ZoomOptions {
   instance: Zoom;
 
   @Input()
   duration: number;
   @Input()
-  zoomInLabel: string | Node;
+  zoomInLabel: string | HTMLElement;
   @Input()
-  zoomOutLabel: string | Node;
+  zoomOutLabel: string | HTMLElement;
   @Input()
   zoomInTipLabel: string;
   @Input()

--- a/projects/ngx-openlayers/src/lib/controls/zoomslider.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/zoomslider.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
-import { ZoomSlider } from 'ol/control';
+import ZoomSlider, { Options as ZoomSliderOptions } from 'ol/control/ZoomSlider';
 import { MapComponent } from '../map.component';
 
 @Component({
@@ -8,7 +8,7 @@ import { MapComponent } from '../map.component';
     <ng-content></ng-content>
   `,
 })
-export class ControlZoomSliderComponent implements OnInit, OnDestroy {
+export class ControlZoomSliderComponent implements OnInit, OnDestroy, ZoomSliderOptions {
   instance: ZoomSlider;
 
   @Input()

--- a/projects/ngx-openlayers/src/lib/controls/zoomtoextent.component.ts
+++ b/projects/ngx-openlayers/src/lib/controls/zoomtoextent.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
-import { ZoomToExtent } from 'ol/control';
+import ZoomToExtent, { Options as ZoomToExtentOptions } from 'ol/control/ZoomToExtent';
 import { MapComponent } from '../map.component';
 import { Extent } from 'ol/extent';
 
@@ -9,13 +9,13 @@ import { Extent } from 'ol/extent';
     <ng-content></ng-content>
   `,
 })
-export class ControlZoomToExtentComponent implements OnInit, OnDestroy {
+export class ControlZoomToExtentComponent implements OnInit, OnDestroy, ZoomToExtentOptions {
   instance: ZoomToExtent;
 
   @Input()
   className: string;
   @Input()
-  label: string | Node;
+  label: string | HTMLElement;
   @Input()
   tipLabel: string;
   @Input()

--- a/projects/ngx-openlayers/src/lib/formats/mvt.component.ts
+++ b/projects/ngx-openlayers/src/lib/formats/mvt.component.ts
@@ -1,21 +1,18 @@
 import { Component, forwardRef, Input } from '@angular/core';
 import { FormatComponent } from './format.component';
-import { MVT } from 'ol/format';
-import { Geometry } from 'ol/geom';
-import GeometryType from 'ol/geom/GeometryType';
+import { FeatureClass } from 'ol/Feature';
+import MVT, { Options as MVTOptions } from 'ol/format/MVT';
 
 @Component({
   selector: 'aol-format-mvt',
   template: '',
   providers: [{ provide: FormatComponent, useExisting: forwardRef(() => FormatMVTComponent) }],
 })
-export class FormatMVTComponent extends FormatComponent {
+export class FormatMVTComponent extends FormatComponent implements MVTOptions {
   instance: MVT;
 
   @Input()
-  featureClass:
-    | ((geom: Geometry | { [k: string]: any }) => any)
-    | ((geom: GeometryType, arg2: number[], arg3: number[] | number[][], arg4: { [k: string]: any }) => any);
+  featureClass: FeatureClass;
   @Input()
   geometryName: string;
   @Input()

--- a/projects/ngx-openlayers/src/lib/interactions/draganddrop.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/draganddrop.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
-import { DragAndDrop } from 'ol/interaction';
-import Feature from 'ol/format/Feature';
+import DragAndDrop, { Options as DragAndDropOptions } from 'ol/interaction/DragAndDrop';
+import FeatureFormat from 'ol/format/Feature';
 import { MapComponent } from '../map.component';
 import { ProjectionLike } from 'ol/proj';
 
@@ -8,15 +8,15 @@ import { ProjectionLike } from 'ol/proj';
   selector: 'aol-interaction-draganddrop',
   template: '',
 })
-export class DragAndDropInteractionComponent implements OnInit, OnDestroy {
+export class DragAndDropInteractionComponent implements OnInit, OnDestroy, DragAndDropOptions {
   instance: DragAndDrop;
 
   @Input()
-  formatConstructors: ((n: Feature) => any)[];
+  formatConstructors: FeatureFormat[];
   @Input()
   projection: ProjectionLike;
   @Input()
-  target: Element;
+  target: HTMLElement;
 
   constructor(private map: MapComponent) {}
 

--- a/projects/ngx-openlayers/src/lib/interactions/dragbox.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/dragbox.component.ts
@@ -1,14 +1,13 @@
 import { Component, OnDestroy, OnInit, Input } from '@angular/core';
-import { DragBox } from 'ol/interaction';
-import { MapComponent } from '../map.component';
+import DragBox, { EndCondition, Options as DragBoxOptions } from 'ol/interaction/DragBox';
 import { Condition } from 'ol/events/condition';
-import { EndCondition } from 'ol/interaction/DragBox';
+import { MapComponent } from '../map.component';
 
 @Component({
   selector: 'aol-interaction-dragbox',
   template: '',
 })
-export class DragBoxInteractionComponent implements OnInit, OnDestroy {
+export class DragBoxInteractionComponent implements OnInit, OnDestroy, DragBoxOptions {
   instance: DragBox;
 
   @Input()
@@ -17,6 +16,8 @@ export class DragBoxInteractionComponent implements OnInit, OnDestroy {
   condition: Condition;
   @Input()
   boxEndCondition: EndCondition;
+
+  onBoxEnd = undefined;
 
   constructor(private map: MapComponent) {}
 

--- a/projects/ngx-openlayers/src/lib/layers/layer.component.ts
+++ b/projects/ngx-openlayers/src/lib/layers/layer.component.ts
@@ -1,5 +1,5 @@
 import { OnDestroy, OnInit, OnChanges, Input, SimpleChanges } from '@angular/core';
-import { Event } from 'ol/events';
+import Event from 'ol/events/Event';
 import { MapComponent } from '../map.component';
 import { LayerGroupComponent } from './layergroup.component';
 import { Extent } from 'ol/extent';

--- a/projects/ngx-openlayers/src/lib/layers/layergroup.component.ts
+++ b/projects/ngx-openlayers/src/lib/layers/layergroup.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit, SkipSelf, Optional } from '@angular/core';
-import { Group } from 'ol/layer';
+import Group, { Options as GroupOptions } from 'ol/layer/Group';
 import { LayerComponent } from './layer.component';
 import { MapComponent } from '../map.component';
 
@@ -9,7 +9,7 @@ import { MapComponent } from '../map.component';
     <ng-content></ng-content>
   `,
 })
-export class LayerGroupComponent extends LayerComponent implements OnInit, OnDestroy {
+export class LayerGroupComponent extends LayerComponent implements OnInit, OnDestroy, GroupOptions {
   public instance: Group;
 
   constructor(

--- a/projects/ngx-openlayers/src/lib/layers/layerimage.component.ts
+++ b/projects/ngx-openlayers/src/lib/layers/layerimage.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnChanges, OnInit, Optional, SimpleChanges } from '@angular/core';
-import { Image } from 'ol/layer';
+import Image from 'ol/layer/Image';
+import { Options as ImageOptions } from 'ol/layer/BaseImage';
 import { MapComponent } from '../map.component';
 import { LayerComponent } from './layer.component';
 import { LayerGroupComponent } from './layergroup.component';
@@ -11,9 +12,7 @@ import { Extent } from 'ol/extent';
     <ng-content></ng-content>
   `,
 })
-export class LayerImageComponent extends LayerComponent implements OnInit, OnChanges {
-  public source: Image;
-
+export class LayerImageComponent extends LayerComponent implements OnInit, OnChanges, ImageOptions {
   @Input()
   opacity: number;
   @Input()

--- a/projects/ngx-openlayers/src/lib/layers/layertile.component.ts
+++ b/projects/ngx-openlayers/src/lib/layers/layertile.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnDestroy, OnInit, Input, Optional, OnChanges, SimpleChanges } from '@angular/core';
-import { Tile } from 'ol/layer';
+import Tile from 'ol/layer/Tile';
+import { Options as TileOptions } from 'ol/layer/BaseTile';
 import { MapComponent } from '../map.component';
 import { LayerComponent } from './layer.component';
 import { LayerGroupComponent } from './layergroup.component';
@@ -10,9 +11,7 @@ import { LayerGroupComponent } from './layergroup.component';
     <ng-content></ng-content>
   `,
 })
-export class LayerTileComponent extends LayerComponent implements OnInit, OnDestroy, OnChanges {
-  public source: Tile;
-
+export class LayerTileComponent extends LayerComponent implements OnInit, OnDestroy, OnChanges, TileOptions {
   @Input()
   preload: number;
   @Input()

--- a/projects/ngx-openlayers/src/lib/layers/layervector.component.ts
+++ b/projects/ngx-openlayers/src/lib/layers/layervector.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnDestroy, OnInit, Input, Optional, OnChanges, SimpleChanges } from '@angular/core';
 import { MapComponent } from '../map.component';
-import { Vector } from 'ol/layer';
+import Vector from 'ol/layer/Vector';
+import { Options as VectorOptions } from 'ol/layer/BaseVector';
 import { Style } from 'ol/style';
 import { StyleFunction } from 'ol/style/Style';
 import { LayerComponent } from './layer.component';
@@ -12,9 +13,7 @@ import { LayerGroupComponent } from './layergroup.component';
     <ng-content></ng-content>
   `,
 })
-export class LayerVectorComponent extends LayerComponent implements OnInit, OnDestroy, OnChanges {
-  public source: Vector;
-
+export class LayerVectorComponent extends LayerComponent implements OnInit, OnDestroy, OnChanges, VectorOptions {
   @Input()
   renderBuffer: number;
 

--- a/projects/ngx-openlayers/src/lib/layers/layervectortile.component.ts
+++ b/projects/ngx-openlayers/src/lib/layers/layervectortile.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Input, Optional, SimpleChanges, OnChanges } from '@angular/core';
-import { VectorTile } from 'ol/layer';
-import { RenderType } from 'ol/layer/VectorTile';
+import VectorTile, { Options as VectorTileOptions } from 'ol/layer/VectorTile';
+import RenderType from 'ol/layer/VectorTileRenderType';
 import { Feature } from 'ol';
 import { Style } from 'ol/style';
 import { MapComponent } from '../map.component';
@@ -14,7 +14,7 @@ import { StyleFunction } from 'ol/style/Style';
     <ng-content></ng-content>
   `,
 })
-export class LayerVectorTileComponent extends LayerComponent implements OnInit, OnChanges {
+export class LayerVectorTileComponent extends LayerComponent implements OnInit, OnChanges, VectorTileOptions {
   @Input()
   renderBuffer: number;
   @Input()

--- a/projects/ngx-openlayers/src/lib/map.component.ts
+++ b/projects/ngx-openlayers/src/lib/map.component.ts
@@ -13,6 +13,7 @@ import Map from 'ol/Map';
 import MapBrowserEvent from 'ol/MapBrowserEvent';
 import MapEvent from 'ol/MapEvent';
 import ObjectEvent from 'ol/Object';
+import { MapOptions } from 'ol/PluggableMap';
 import RenderEvent from 'ol/render/Event';
 import { Control } from 'ol/control';
 import { Interaction } from 'ol/interaction';
@@ -24,7 +25,7 @@ import { Interaction } from 'ol/interaction';
     <ng-content></ng-content>
   `,
 })
-export class MapComponent implements OnInit, AfterViewInit, OnChanges {
+export class MapComponent implements OnInit, AfterViewInit, OnChanges, MapOptions {
   public instance: Map;
   public componentType = 'map';
 
@@ -35,7 +36,7 @@ export class MapComponent implements OnInit, AfterViewInit, OnChanges {
   @Input()
   pixelRatio: number;
   @Input()
-  keyboardEventTarget: Element | string;
+  keyboardEventTarget: HTMLElement | string;
   @Input()
   loadTilesWhileAnimating: boolean;
   @Input()

--- a/projects/ngx-openlayers/src/lib/overlay.component.ts
+++ b/projects/ngx-openlayers/src/lib/overlay.component.ts
@@ -1,17 +1,17 @@
 import { Component, ContentChild, Input, OnDestroy, OnInit } from '@angular/core';
-import { MapComponent } from './map.component';
-import { Overlay, PanOptions } from 'ol';
-import { ContentComponent } from './content.component';
+import Overlay, { Options as OverlayOptions, PanOptions } from 'ol/Overlay';
 import OverlayPositioning from 'ol/OverlayPositioning';
+import { ContentComponent } from './content.component';
+import { MapComponent } from './map.component';
 
 @Component({
   selector: 'aol-overlay',
   template: '<ng-content></ng-content>',
 })
-export class OverlayComponent implements OnInit, OnDestroy {
+export class OverlayComponent implements OnInit, OnDestroy, OverlayOptions {
   componentType = 'overlay';
   instance: Overlay;
-  element: Element;
+  element: HTMLElement;
   @ContentChild(ContentComponent, { static: true })
   content: ContentComponent;
 
@@ -20,7 +20,7 @@ export class OverlayComponent implements OnInit, OnDestroy {
   @Input()
   offset: number[];
   @Input()
-  positioning: OverlayPositioning | string;
+  positioning: OverlayPositioning;
   @Input()
   stopEvent: boolean;
   @Input()

--- a/projects/ngx-openlayers/src/lib/sources/bingmaps.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/bingmaps.component.ts
@@ -1,5 +1,5 @@
 import { Component, Host, Input, OnInit, forwardRef } from '@angular/core';
-import { BingMaps } from 'ol/source';
+import BingMaps, { Options as BingMapsOptions } from 'ol/source/BingMaps';
 import { SourceComponent } from './source.component';
 import { LayerTileComponent } from '../layers/layertile.component';
 import { LoadFunction } from 'ol/Tile';
@@ -11,7 +11,7 @@ import { LoadFunction } from 'ol/Tile';
   `,
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceBingmapsComponent) }],
 })
-export class SourceBingmapsComponent extends SourceComponent implements OnInit {
+export class SourceBingmapsComponent extends SourceComponent implements OnInit, BingMapsOptions {
   instance: BingMaps;
 
   @Input()

--- a/projects/ngx-openlayers/src/lib/sources/cluster.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/cluster.component.ts
@@ -9,12 +9,13 @@ import {
   OnChanges,
 } from '@angular/core';
 import { Feature } from 'ol';
+import { Point } from 'ol/geom';
+import { Vector } from 'ol/source';
+import Cluster, { Options as ClusterOptions } from 'ol/source/Cluster';
 import { LayerVectorComponent } from '../layers/layervector.component';
 import { TileGridComponent } from '../tilegrid.component';
 import { SourceComponent } from './source.component';
 import { SourceVectorComponent } from './vector.component';
-import { Cluster, Vector } from 'ol/source';
-import { Point } from 'ol/geom';
 
 @Component({
   selector: 'aol-source-cluster',
@@ -23,7 +24,7 @@ import { Point } from 'ol/geom';
   `,
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceClusterComponent) }],
 })
-export class SourceClusterComponent extends SourceComponent implements AfterContentInit, OnChanges {
+export class SourceClusterComponent extends SourceComponent implements AfterContentInit, OnChanges, ClusterOptions {
   instance: Cluster;
 
   @Input()

--- a/projects/ngx-openlayers/src/lib/sources/geojson.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/geojson.component.ts
@@ -1,9 +1,9 @@
 import { Component, Host, Input, OnInit, forwardRef } from '@angular/core';
 import { LayerVectorComponent } from '../layers/layervector.component';
 import { SourceComponent } from './source.component';
-import { Feature } from 'ol';
-import { Vector } from 'ol/source';
-import { GeoJSON } from 'ol/format';
+import FeatureFormat from 'ol/format/Feature';
+import Vector, { Options as VectorOptions } from 'ol/source/Vector';
+import GeoJSON, { Options as GeoJSONOptions } from 'ol/format/GeoJSON';
 import { ProjectionLike } from 'ol/proj';
 
 @Component({
@@ -13,9 +13,9 @@ import { ProjectionLike } from 'ol/proj';
   `,
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceGeoJSONComponent) }],
 })
-export class SourceGeoJSONComponent extends SourceComponent implements OnInit {
+export class SourceGeoJSONComponent extends SourceComponent implements OnInit, VectorOptions, GeoJSONOptions {
   instance: Vector;
-  format: Feature;
+  format: FeatureFormat;
   @Input()
   defaultDataProjection: ProjectionLike;
   @Input()

--- a/projects/ngx-openlayers/src/lib/sources/imagearcgisrest.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/imagearcgisrest.component.ts
@@ -9,7 +9,7 @@ import {
   Output,
   SimpleChanges,
 } from '@angular/core';
-import { ImageArcGISRest } from 'ol/source';
+import ImageArcGISRest, { Options as ImageArcGISRestOptions } from 'ol/source/ImageArcGISRest';
 import { LayerImageComponent } from '../layers/layerimage.component';
 import { SourceComponent } from './source.component';
 import { ProjectionLike } from 'ol/proj';
@@ -24,12 +24,13 @@ import { ImageSourceEvent } from 'ol/source/Image';
   `,
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceImageArcGISRestComponent) }],
 })
-export class SourceImageArcGISRestComponent extends SourceComponent implements OnInit, OnChanges {
+export class SourceImageArcGISRestComponent extends SourceComponent
+  implements OnInit, OnChanges, ImageArcGISRestOptions {
   instance: ImageArcGISRest;
 
-  @Input() projection: ProjectionLike | string;
+  @Input() projection: ProjectionLike;
   @Input() url: string;
-  @Input() attributions: AttributionLike[];
+  @Input() attributions: AttributionLike;
   @Input() crossOrigin?: string;
   @Input() imageLoadFunction?: LoadFunction;
   @Input() params?: { [k: string]: any };

--- a/projects/ngx-openlayers/src/lib/sources/imagestatic.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/imagestatic.component.ts
@@ -9,7 +9,7 @@ import {
   SimpleChanges,
   OnInit,
 } from '@angular/core';
-import { ImageStatic } from 'ol/source';
+import ImageStatic, { Options as ImageStaticOptions } from 'ol/source/ImageStatic';
 import { SourceComponent } from './source.component';
 import { LayerImageComponent } from '../layers/layerimage.component';
 import { ProjectionLike } from 'ol/proj';
@@ -26,11 +26,11 @@ import { ImageSourceEvent } from 'ol/source/Image';
   `,
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceImageStaticComponent) }],
 })
-export class SourceImageStaticComponent extends SourceComponent implements OnInit, OnChanges {
+export class SourceImageStaticComponent extends SourceComponent implements OnInit, OnChanges, ImageStaticOptions {
   instance: ImageStatic;
 
   @Input()
-  projection: ProjectionLike | string;
+  projection: ProjectionLike;
   @Input()
   imageExtent: Extent;
   @Input()

--- a/projects/ngx-openlayers/src/lib/sources/imagewms.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/imagewms.component.ts
@@ -9,13 +9,14 @@ import {
   Output,
   EventEmitter,
 } from '@angular/core';
-import { ImageWMS } from 'ol/source';
-import { LayerImageComponent } from '../layers/layerimage.component';
-import { SourceComponent } from './source.component';
+import ImageWMS, { Options as ImageWMSOptions } from 'ol/source/ImageWMS';
 import { ProjectionLike } from 'ol/proj';
 import { AttributionLike } from 'ol/source/Source';
 import { LoadFunction } from 'ol/Image';
 import { ImageSourceEvent } from 'ol/source/Image';
+import WMSServerType from 'ol/source/WMSServerType';
+import { LayerImageComponent } from '../layers/layerimage.component';
+import { SourceComponent } from './source.component';
 
 @Component({
   selector: 'aol-source-imagewms',
@@ -24,7 +25,7 @@ import { ImageSourceEvent } from 'ol/source/Image';
   `,
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceImageWMSComponent) }],
 })
-export class SourceImageWMSComponent extends SourceComponent implements OnChanges, OnInit {
+export class SourceImageWMSComponent extends SourceComponent implements OnChanges, OnInit, ImageWMSOptions {
   instance: ImageWMS;
 
   @Input()
@@ -34,17 +35,17 @@ export class SourceImageWMSComponent extends SourceComponent implements OnChange
   @Input()
   hidpi: boolean;
   @Input()
-  serverType: string;
+  serverType: WMSServerType | string;
   @Input()
   imageLoadFunction?: LoadFunction;
   @Input()
   params: { [key: string]: any };
   @Input()
-  projection: ProjectionLike | string;
+  projection: ProjectionLike;
   @Input()
   ratio: number;
   @Input()
-  resolutions: Array<number>;
+  resolutions: number[];
   @Input()
   url: string;
 

--- a/projects/ngx-openlayers/src/lib/sources/osm.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/osm.component.ts
@@ -1,5 +1,5 @@
 import { Component, Host, forwardRef, Input, AfterContentInit, Optional, Output, EventEmitter } from '@angular/core';
-import { OSM } from 'ol/source';
+import OSM, { Options as OSMOptions } from 'ol/source/OSM';
 import { LayerTileComponent } from '../layers/layertile.component';
 import { SourceComponent } from './source.component';
 import { SourceXYZComponent } from './xyz.component';
@@ -15,7 +15,7 @@ import { TileSourceEvent } from 'ol/source/Tile';
   `,
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceOsmComponent) }],
 })
-export class SourceOsmComponent extends SourceXYZComponent implements AfterContentInit {
+export class SourceOsmComponent extends SourceXYZComponent implements AfterContentInit, OSMOptions {
   instance: OSM;
 
   @Input()

--- a/projects/ngx-openlayers/src/lib/sources/raster.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/raster.component.ts
@@ -1,6 +1,6 @@
 import { AfterContentInit, Component, EventEmitter, forwardRef, Host, Input, Output } from '@angular/core';
-import { Raster, Source } from 'ol/source';
-import { RasterOperationType, RasterSourceEvent } from 'ol/source/Raster';
+import { Source } from 'ol/source';
+import Raster, { Options as RasterOptions, RasterSourceEvent } from 'ol/source/Raster';
 import { LayerImageComponent } from '../layers/layerimage.component';
 import { SourceComponent } from './source.component';
 import { Operation } from 'ol/source/Raster';
@@ -17,7 +17,7 @@ import { Operation } from 'ol/source/Raster';
     },
   ],
 })
-export class SourceRasterComponent extends SourceComponent implements AfterContentInit {
+export class SourceRasterComponent extends SourceComponent implements AfterContentInit, RasterOptions {
   instance: Raster;
 
   @Input()
@@ -27,7 +27,7 @@ export class SourceRasterComponent extends SourceComponent implements AfterConte
   @Input()
   lib?: any;
   @Input()
-  operationType?: RasterOperationType;
+  operationType?: 'pixel' | 'image';
 
   @Output()
   beforeOperations: EventEmitter<RasterSourceEvent> = new EventEmitter<RasterSourceEvent>();

--- a/projects/ngx-openlayers/src/lib/sources/source.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/source.component.ts
@@ -1,5 +1,5 @@
 import { Input, OnDestroy } from '@angular/core';
-import { Source } from 'ol';
+import Source from 'ol/source/Source';
 import { LayerComponent } from '../layers/layer.component';
 import { SourceRasterComponent } from './raster.component';
 

--- a/projects/ngx-openlayers/src/lib/sources/tilejson.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/tilejson.component.ts
@@ -1,5 +1,5 @@
 import { Component, Host, Input, OnInit, forwardRef } from '@angular/core';
-import { TileJSON } from 'ol/source';
+import TileJSON, { Options as TileJSONOptions } from 'ol/source/TileJSON';
 import { LayerTileComponent } from '../layers/layertile.component';
 import { SourceComponent } from './source.component';
 
@@ -10,7 +10,7 @@ import { SourceComponent } from './source.component';
   `,
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceTileJSONComponent) }],
 })
-export class SourceTileJSONComponent extends SourceComponent implements OnInit {
+export class SourceTileJSONComponent extends SourceComponent implements OnInit, TileJSONOptions {
   instance: TileJSON;
 
   @Input()

--- a/projects/ngx-openlayers/src/lib/sources/tilewms.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/tilewms.component.ts
@@ -1,9 +1,9 @@
 import { Component, Host, Input, OnChanges, OnInit, forwardRef, SimpleChanges } from '@angular/core';
+import TileWMS, { Options as TileWMSOptions } from 'ol/source/TileWMS';
+import TileGrid from 'ol/tilegrid/TileGrid';
+import { LoadFunction } from 'ol/Tile';
 import { LayerTileComponent } from '../layers/layertile.component';
 import { SourceComponent } from './source.component';
-import { TileWMS } from 'ol/source';
-import { TileGrid } from 'ol/tilegrid';
-import { LoadFunction } from 'ol/Tile';
 
 @Component({
   selector: 'aol-source-tilewms',
@@ -12,7 +12,7 @@ import { LoadFunction } from 'ol/Tile';
   `,
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceTileWMSComponent) }],
 })
-export class SourceTileWMSComponent extends SourceComponent implements OnChanges, OnInit {
+export class SourceTileWMSComponent extends SourceComponent implements OnChanges, OnInit, TileWMSOptions {
   instance: TileWMS;
   @Input()
   cacheSize: number;

--- a/projects/ngx-openlayers/src/lib/sources/tilewmts.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/tilewmts.component.ts
@@ -13,9 +13,9 @@ import {
 import { LayerTileComponent } from '../layers/layertile.component';
 import { SourceComponent } from './source.component';
 import { TileGridWMTSComponent } from '../tilegridwmts.component';
-import { WMTS } from 'ol/source';
-import { WMTS as TileGridWMTS } from 'ol/tilegrid';
-import { WMTSRequestEncoding } from 'ol/source';
+import WMTS, { Options as WMTSOptions } from 'ol/source/WMTS';
+import WMTSTileGrid from 'ol/tilegrid/WMTS';
+import WMTSRequestEncoding from 'ol/source/WMTSRequestEncoding';
 import { ProjectionLike } from 'ol/proj';
 import { LoadFunction } from 'ol/Tile';
 import { TileSourceEvent } from 'ol/source/Tile';
@@ -27,14 +27,14 @@ import { TileSourceEvent } from 'ol/source/Tile';
   `,
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceTileWMTSComponent) }],
 })
-export class SourceTileWMTSComponent extends SourceComponent implements AfterContentInit, OnChanges {
+export class SourceTileWMTSComponent extends SourceComponent implements AfterContentInit, OnChanges, WMTSOptions {
   instance: WMTS;
   @Input()
   cacheSize?: number;
   @Input()
   crossOrigin?: string;
   @Input()
-  tileGrid: TileGridWMTS;
+  tileGrid: WMTSTileGrid;
   @Input()
   projection: ProjectionLike;
   @Input()

--- a/projects/ngx-openlayers/src/lib/sources/utfgrid.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/utfgrid.component.ts
@@ -1,7 +1,8 @@
 import { Component, Host, Input, OnInit, forwardRef } from '@angular/core';
+import UTFGrid, { Options as UTFGridOptions } from 'ol/source/UTFGrid';
+import { Config as TileJSONConfig } from 'ol/source/TileJSON';
 import { SourceComponent } from './source.component';
 import { LayerTileComponent } from '../layers/layertile.component';
-import { UTFGrid } from 'ol/source';
 
 @Component({
   selector: 'aol-source-utfgrid',
@@ -10,9 +11,9 @@ import { UTFGrid } from 'ol/source';
   `,
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceUTFGridComponent) }],
 })
-export class SourceUTFGridComponent extends SourceComponent implements OnInit {
+export class SourceUTFGridComponent extends SourceComponent implements OnInit, UTFGridOptions {
   instance: UTFGrid;
-  @Input() tileJSON: JSON;
+  @Input() tileJSON: TileJSONConfig;
   @Input() url: string;
 
   constructor(@Host() layer: LayerTileComponent) {

--- a/projects/ngx-openlayers/src/lib/sources/vector.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/vector.component.ts
@@ -1,5 +1,5 @@
 import { Component, Host, Input, OnInit, forwardRef } from '@angular/core';
-import { Vector } from 'ol/source';
+import Vector, { Options as VectorOptions } from 'ol/source/Vector';
 import Feature from 'ol/format/Feature';
 import { LayerVectorComponent } from '../layers/layervector.component';
 import { SourceComponent } from './source.component';
@@ -12,7 +12,7 @@ import { LoadingStrategy } from 'ol/source/Vector';
   `,
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceVectorComponent) }],
 })
-export class SourceVectorComponent extends SourceComponent implements OnInit {
+export class SourceVectorComponent extends SourceComponent implements OnInit, VectorOptions {
   instance: Vector;
   @Input()
   overlaps: boolean;

--- a/projects/ngx-openlayers/src/lib/sources/vectortile.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/vectortile.component.ts
@@ -1,13 +1,13 @@
 import { Component, Host, Input, forwardRef, ContentChild, AfterContentInit } from '@angular/core';
-import { VectorTile } from 'ol';
+import VectorTile, { Options as VectorTileOptions } from 'ol/source/VectorTile';
 import Feature from 'ol/format/Feature';
 import TileGrid from 'ol/tilegrid/TileGrid';
+import { ProjectionLike } from 'ol/proj';
+import { UrlFunction } from 'ol/Tile';
 import { LayerVectorTileComponent } from '../layers/layervectortile.component';
 import { FormatComponent } from '../formats/format.component';
 import { TileGridComponent } from '../tilegrid.component';
 import { SourceComponent } from './source.component';
-import { ProjectionLike } from 'ol/proj';
-import { UrlFunction } from 'ol/Tile';
 
 @Component({
   selector: 'aol-source-vectortile',
@@ -16,7 +16,7 @@ import { UrlFunction } from 'ol/Tile';
   `,
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceVectorTileComponent) }],
 })
-export class SourceVectorTileComponent extends SourceComponent implements AfterContentInit {
+export class SourceVectorTileComponent extends SourceComponent implements AfterContentInit, VectorTileOptions {
   public instance: VectorTile;
   @Input()
   cacheSize: number;

--- a/projects/ngx-openlayers/src/lib/sources/xyz.component.ts
+++ b/projects/ngx-openlayers/src/lib/sources/xyz.component.ts
@@ -11,7 +11,7 @@ import {
   Output,
   EventEmitter,
 } from '@angular/core';
-import { XYZ } from 'ol/source';
+import XYZ, { Options as XYZOptions } from 'ol/source/XYZ';
 import { LayerTileComponent } from '../layers/layertile.component';
 import { SourceComponent } from './source.component';
 import { TileGridComponent } from '../tilegrid.component';
@@ -28,7 +28,7 @@ import { LoadFunction, UrlFunction } from 'ol/Tile';
   `,
   providers: [{ provide: SourceComponent, useExisting: forwardRef(() => SourceXYZComponent) }],
 })
-export class SourceXYZComponent extends SourceComponent implements AfterContentInit, OnChanges {
+export class SourceXYZComponent extends SourceComponent implements AfterContentInit, OnChanges, XYZOptions {
   instance: XYZ;
   @Input()
   cacheSize: number;

--- a/projects/ngx-openlayers/src/lib/styles/circle.component.ts
+++ b/projects/ngx-openlayers/src/lib/styles/circle.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, Host, AfterContentInit, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
-import { AtlasManager, Circle, Fill, Stroke } from 'ol/style';
+import { Circle, Fill, Stroke } from 'ol/style';
 import { StyleComponent } from './style.component';
 
 @Component({
@@ -20,8 +20,6 @@ export class StyleCircleComponent implements AfterContentInit, OnChanges, OnDest
   snapToPixel: boolean;
   @Input()
   stroke: Stroke;
-  @Input()
-  atlasManager: AtlasManager;
 
   constructor(@Host() private host: StyleComponent) {}
 

--- a/projects/ngx-openlayers/src/lib/styles/icon.component.ts
+++ b/projects/ngx-openlayers/src/lib/styles/icon.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, Host, OnInit, OnChanges, SimpleChanges } from '@angular/core';
-import { Icon } from 'ol/style';
+import Icon, { Options as IconOptions } from 'ol/style/Icon';
 import IconAnchorUnits from 'ol/style/IconAnchorUnits';
 import IconOrigin from 'ol/style/IconOrigin';
 import { StyleComponent } from './style.component';
@@ -10,7 +10,7 @@ import { StyleComponent } from './style.component';
     <div class="aol-style-icon"></div>
   `,
 })
-export class StyleIconComponent implements OnInit, OnChanges {
+export class StyleIconComponent implements OnInit, OnChanges, IconOptions {
   public instance: Icon;
 
   @Input()
@@ -26,7 +26,7 @@ export class StyleIconComponent implements OnInit, OnChanges {
   @Input()
   crossOrigin: IconOrigin;
   @Input()
-  img: string;
+  img: HTMLImageElement | HTMLCanvasElement;
   @Input()
   offset: [number, number];
   @Input()

--- a/projects/ngx-openlayers/src/lib/styles/stroke.component.ts
+++ b/projects/ngx-openlayers/src/lib/styles/stroke.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, Optional, OnInit, OnChanges, SimpleChanges } from '@angular/core';
-import { Stroke } from 'ol/style';
+import Stroke, { Options as StrokeOptions } from 'ol/style/Stroke';
 import { StyleComponent } from './style.component';
 import { StyleCircleComponent } from './circle.component';
 import { StyleTextComponent } from './text.component';
@@ -11,7 +11,7 @@ import { Color } from 'ol/color';
     <div class="aol-style-stroke"></div>
   `,
 })
-export class StyleStrokeComponent implements OnInit, OnChanges {
+export class StyleStrokeComponent implements OnInit, OnChanges, StrokeOptions {
   public instance: Stroke;
   /* the typings do not have the setters */
   private host: /*StyleComponent|StyleCircleComponent|StyleTextComponent*/ any;
@@ -19,11 +19,11 @@ export class StyleStrokeComponent implements OnInit, OnChanges {
   @Input()
   color: Color | undefined;
   @Input()
-  lineCap: string | undefined;
+  lineCap: 'butt' | 'round' | 'square';
   @Input()
   lineDash: number[] | undefined;
   @Input()
-  lineJoin: string | undefined;
+  lineJoin: 'bevel' | 'round' | 'miter';
   @Input()
   miterLimit: number | undefined;
   @Input()

--- a/projects/ngx-openlayers/src/lib/tilegridwmts.component.ts
+++ b/projects/ngx-openlayers/src/lib/tilegridwmts.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
-import WMTS from 'ol/tilegrid/WMTS';
+import WMTS, { Options as WMTSOptions } from 'ol/tilegrid/WMTS';
 import { TileGridComponent } from './tilegrid.component';
 import { Coordinate } from 'ol/coordinate';
 import { Size } from 'ol/size';
@@ -8,7 +8,7 @@ import { Size } from 'ol/size';
   selector: 'aol-tilegrid-wmts',
   template: '',
 })
-export class TileGridWMTSComponent extends TileGridComponent implements OnInit {
+export class TileGridWMTSComponent extends TileGridComponent implements OnInit, WMTSOptions {
   instance: WMTS;
 
   @Input()
@@ -22,7 +22,7 @@ export class TileGridWMTSComponent extends TileGridComponent implements OnInit {
   @Input()
   sizes?: Size[];
   @Input()
-  tileSizes?: (number | Size)[];
+  tileSizes?: Size[];
   @Input()
   widths?: number[];
 

--- a/projects/ngx-openlayers/src/lib/view.component.ts
+++ b/projects/ngx-openlayers/src/lib/view.component.ts
@@ -1,9 +1,10 @@
 import { Component, Input, OnInit, OnChanges, OnDestroy, SimpleChanges, EventEmitter, Output } from '@angular/core';
-import View from 'ol/View';
-import { MapComponent } from './map.component';
-import { ObjectEvent } from 'ol';
-import { Extent } from 'ol/extent';
+import { ObjectEvent } from 'ol/Object';
 import { Coordinate } from 'ol/coordinate';
+import { ProjectionLike } from 'ol/proj';
+import View, { ViewOptions } from 'ol/View';
+import { Extent } from 'ol/extent';
+import { MapComponent } from './map.component';
 
 @Component({
   selector: 'aol-view',
@@ -11,7 +12,7 @@ import { Coordinate } from 'ol/coordinate';
     <ng-content></ng-content>
   `,
 })
-export class ViewComponent implements OnInit, OnChanges, OnDestroy {
+export class ViewComponent implements OnInit, OnChanges, OnDestroy, ViewOptions {
   public instance: View;
   public componentType = 'view';
 
@@ -42,7 +43,7 @@ export class ViewComponent implements OnInit, OnChanges, OnDestroy {
   @Input()
   center: Coordinate;
   @Input()
-  projection: string;
+  projection: ProjectionLike;
   @Input()
   zoomAnimation = false;
 

--- a/src/app/modify-polygon/modify-polygon.component.ts
+++ b/src/app/modify-polygon/modify-polygon.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { Feature } from 'ol';
+import { Feature, Polygon } from 'geojson';
+import OLFeature from 'ol/Feature';
 import Projection from 'ol/proj/Projection';
 import { GeoJSON } from 'ol/format';
 
@@ -66,7 +67,7 @@ export class ModifyPolygonComponent implements OnInit {
   displayProj = new Projection({ code: 'EPSG:3857' });
   inputProj = new Projection({ code: 'EPSG:4326' });
 
-  feature: Feature = {
+  feature: Feature<Polygon> = {
     geometry: {
       coordinates: [
         [
@@ -85,10 +86,10 @@ export class ModifyPolygonComponent implements OnInit {
 
   ngOnInit() {}
 
-  modifyEnd(feature: Feature) {
+  modifyEnd(feature: OLFeature) {
     this.feature = this.format.writeFeatureObject(feature, {
       dataProjection: this.inputProj,
       featureProjection: this.displayProj,
-    });
+    }) as Feature<Polygon>;
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,9 @@
     "paths": {
       "ngx-openlayers": [
         "dist/ngx-openlayers"
-      ]
+      ],
+      "ol": ["node_modules/@hanreev/types-ol/ol"],
+      "ol/*": ["node_modules/@hanreev/types-ol/ol/*"]
     }
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
This is a redo of #244, rebased on top of the latest `next` branch to bring in the changes to support Angular 8 and OpenLayers 6.

I understand if this is adding more type annotations than this project would like to support, but of particular interest to me is getting the imports fixed in the few cases were they were wrong:
 - https://github.com/quentin-ol/ngx-openlayers/compare/next...maurizi:fix-ol-6-typings?expand=1#diff-c13420342eed263944d04354d20a9bc2
 - https://github.com/quentin-ol/ngx-openlayers/compare/next...maurizi:fix-ol-6-typings?expand=1#diff-a29fb05b1edbbc1b8de7cf27493f0aac

I can open a smaller-scope pull request with just those changes if that would be preferred.