### PR TITLE
add support to `onFocusOnly` option for interactions

### DIFF
--- a/projects/ngx-openlayers/src/lib/interactions/default.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/default.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { defaults, Interaction } from 'ol/interaction';
 import { Collection } from 'ol';
 import { MapComponent } from '../map.component';
@@ -9,11 +9,13 @@ import { MapComponent } from '../map.component';
 })
 export class DefaultInteractionComponent implements OnInit, OnDestroy {
   instance: Collection<Interaction>;
+  @Input()
+  public onFocusOnly: boolean;
 
   constructor(private map: MapComponent) {}
 
   ngOnInit() {
-    this.instance = defaults();
+    this.instance = defaults(this);
     this.instance.forEach((i) => this.map.instance.addInteraction(i));
   }
 

--- a/projects/ngx-openlayers/src/lib/interactions/dragpan.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/dragpan.component.ts
@@ -15,6 +15,8 @@ export class DragPanInteractionComponent implements OnInit, OnDestroy {
   condition: Condition;
   @Input()
   kinetic: Kinetic;
+  @Input()
+  onFocusOnly: boolean;
 
   constructor(private map: MapComponent) {}
 

--- a/projects/ngx-openlayers/src/lib/interactions/mousewheelzoom.component.ts
+++ b/projects/ngx-openlayers/src/lib/interactions/mousewheelzoom.component.ts
@@ -14,6 +14,8 @@ export class MouseWheelZoomInteractionComponent implements OnInit, OnDestroy {
   timeout: number;
   @Input()
   useAnchor: boolean;
+  @Input()
+  onFocusOnly: boolean;
 
   constructor(private map: MapComponent) {}
 

--- a/projects/ngx-openlayers/src/lib/map.component.ts
+++ b/projects/ngx-openlayers/src/lib/map.component.ts
@@ -20,7 +20,7 @@ import { Interaction } from 'ol/interaction';
 @Component({
   selector: 'aol-map',
   template: `
-    <div [style.width]="width" [style.height]="height"></div>
+    <div [style.width]="width" [style.height]="height" [attr.tabindex]="tabindex"></div>
     <ng-content></ng-content>
   `,
 })
@@ -44,6 +44,8 @@ export class MapComponent implements OnInit, AfterViewInit, OnChanges {
   logo: string | boolean;
   @Input()
   renderer: 'canvas' | 'webgl';
+  @Input()
+  tabindex: number = null;
 
   @Output()
   olClick: EventEmitter<MapBrowserEvent>;


### PR DESCRIPTION
Add support to `onFocusOnly` option that is available on `ol/interaction/MouseWheelZoom` and on `ol/interaction/DragPan` (and `ol/interaction.defaults` for completeness).

For the site I'm developing right now this is a must, since we have lots of scrollable content on a page with a map. Without `onFocusOnly` the map traps the mouse wheel, resulting in a bad user experience.

**Please note** that the `tabindex` thing in `<aol-map>` is needed for the [`focusWithTabindex`](https://github.com/openlayers/openlayers/blob/3a01e083c65f201ffb89ea814da8136ac8ef5c71/src/ol/events/condition.js#L91) condition to work inside OpenLayers. I don't expect any breaking change in this PR, given that in using `[attr.tabindex]` with `null` will effectively not set tabindex (as it occurs before the PR). Also, `tabindex` property didn't exist in `aol-map` altogether (so nobody should be using it).